### PR TITLE
Minor cleanup of Tammann notebook

### DIFF
--- a/Euler_equations_TammannEOS.ipynb
+++ b/Euler_equations_TammannEOS.ipynb
@@ -365,130 +365,89 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "ql = [1010.0, 0.0, 3*101325.0]\n",
-    "qr = [1000.0, 0.0, 101325.0]\n",
-    "gamma = [7.15, 7.15]\n",
-    "pinf = [300000000.0, 300000000.0]\n",
-    "ex_states, ex_speeds, reval, wave_types, varsout = euler_tammann.exact_riemann_solution(ql ,qr, gamma, pinf, \n",
-    "                                                              varin = 'primitive', varout = 'primitive')"
+    "def plot_riemann_solution(q_l, q_r, gamma, pinf):\n",
+    "    ex_states, ex_speeds, reval, wave_types, varsout = \\\n",
+    "        euler_tammann.exact_riemann_solution(q_l ,q_r, gamma, pinf, \n",
+    "                                             varin='primitive', varout='primitive')\n",
+    "\n",
+    "    plot_function = riemann_tools.make_plot_function(ex_states, ex_speeds, \n",
+    "                                                     reval, wave_types, \n",
+    "                                                     layout='vertical', \n",
+    "                                                     variable_names=euler_tammann.primitive_variables)\n",
+    "\n",
+    "    return interact(plot_function, t=widgets.FloatSlider(value=0.0,min=0,max=1.0));\n",
+    "\n",
+    "gamma_water = 7.15\n",
+    "gamma_air = 1.4\n",
+    "pinf_water = 3.e8\n",
+    "pinf_air = 0."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "plot_function = riemann_tools.make_plot_function(ex_states, ex_speeds, reval, wave_types, layout='vertical', \n",
-    "                                                 variable_names=euler_tammann.primitive_variables)\n",
+    "q_l = [1010.0, 0.0, 3*101325.0]\n",
+    "q_r = [1000.0, 0.0, 101325.0]\n",
+    "gamma = [gamma_water, gamma_water]\n",
+    "pinf = [pinf_water, pinf_water]\n",
     "\n",
-    "interact(plot_function, t=widgets.FloatSlider(value=0.0,min=0,max=1.0));"
+    "plot_riemann_solution(q_l, q_r, gamma, pinf);"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Problem 2: Air-water interface in shock tube\n",
-    "Euler equations with a Tammann EOS allows us to model wave propagation on almost incompressible media, as water. As we provided the solution with different EOS parameters on the left and right states, it can couple different materials across the interface. For instance, we can use this model to study the propagation of waves from air into water. Air is modeled by the ideal gas EOS, which corresponds to $\\gamma=1.4$ and $p_{\\infty} = 0$, and water can be modeled using the same parameters as the example before. Consider a shock traveling from left to right; the left state has only air while the right state has only water. Although in a realistic two or three dimensional setting, the water would spill into the left state, we can consider the water is being held in place by a container with a thin wall. In this setting, the current model has been shown to be a valid approximation <cite data-cite=\"del2016computational0\"><a href=\"riemann.html#del2016computational0\">(del Razo 2016)<a></cite>. The solution has the following form:"
+    "We can use the Euler equations with the Tammann EOS to model wave propagation in almost-incompressible media, such as water. As we provided the solution with different EOS parameters on the left and right states, it can couple different materials across the interface. For instance, we can use this model to study the propagation of waves from air into water. Air is modeled by the ideal gas EOS, which corresponds to $\\gamma=1.4$ and $p_{\\infty} = 0$, and water can be modeled using the same parameters as the example before. Consider a shock traveling from left to right; the left state has only air while the right state has only water. Although in a realistic two or three dimensional setting, the water would spill into the left state, we can consider the water is being held in place by a container with a thin wall. In this setting, the current model has been shown to be a valid approximation <cite data-cite=\"del2016computational0\"><a href=\"riemann.html#del2016computational0\">(del Razo 2016)<a></cite>. The solution has the following form:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ql = [1.0, 350.0, 200000.0] # Initial condition for shock in air\n",
-    "qr = [1000.0, 0.0, 101325.0] # Initial condition in still water\n",
-    "gamma = [1.4, 7.15]\n",
-    "pinf = [0.0, 300000000.0]\n",
-    "ex_states, ex_speeds, reval, wave_types, varsout = euler_tammann.exact_riemann_solution(ql ,qr, gamma, pinf, \n",
-    "                                                              varin = 'primitive', varout = 'primitive')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "plot_function = riemann_tools.make_plot_function(ex_states, ex_speeds, reval, wave_types, layout='vertical', \n",
-    "                                                 variable_names=euler_tammann.primitive_variables)\n",
-    "interact(plot_function, t=widgets.FloatSlider(value=0.0,min=0,max=1.0));"
+    "q_l = [1.0, 350.0, 200000.0] # Initial condition for shock in air\n",
+    "q_r = [1000.0, 0.0, 101325.0] # Initial condition in still water\n",
+    "gamma = [gamma_air, gamma_water]\n",
+    "pinf = [pinf_air, pinf_water]\n",
+    "\n",
+    "plot_riemann_solution(q_l, q_r, gamma, pinf);"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Problem 3: Water-air interface in shock tube\n",
-    "The same setup as in Problem 2, but now the shock moves from water into air."
+    "The same setup as in Problem 2, but now the shock moves from water (on the left) into air (on the right)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ql = [1000.0, 350.0, 200000.0] # Initial condition for shock in air\n",
-    "qr = [1.0, 0.0, 101325.0] # Initial condition in still water\n",
-    "gamma = [7.15, 1.4]\n",
-    "pinf = [300000000.0, 0.0]\n",
-    "ex_states, ex_speeds, reval, wave_types, varsout = euler_tammann.exact_riemann_solution(ql ,qr, gamma, pinf, \n",
-    "                                                              varin = 'primitive', varout = 'primitive')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "plot_function = riemann_tools.make_plot_function(ex_states, ex_speeds, reval, wave_types, layout='vertical', \n",
-    "                                                 variable_names=euler_tammann.primitive_variables)\n",
-    "interact(plot_function, t=widgets.FloatSlider(value=0.0,min=0,max=1.0));"
+    "q_l = [1000.0, 350.0, 200000.0] # Initial condition for shock in air\n",
+    "q_r = [1.0, 0.0, 101325.0] # Initial condition in still water\n",
+    "gamma = [gamma_water, gamma_air]\n",
+    "pinf = [pinf_water, pinf_air]\n",
+    "\n",
+    "plot_riemann_solution(q_l, q_r, gamma, pinf);"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Problem 4: Strong symmetric expansion in water (unphysical)\n",
     "We consider a strong symmetric expansion wave in water. Analogous to the Euler equations using an ideal gas EOS, we consider equal densities and pressures, and equal and opposite velocities, with the initial states moving away from each other.  The result is two rarefaction waves (the contact has zero strength). However, notice the value in the pressure plot is several orders of magnitude below zero. This is an unphysical result, so it is important to be aware this can happen when using the Tammann EOS in some extreme cases.\n"
@@ -497,42 +456,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ql = [1000.0, -350.0, 2*101325.0] # Initial condition for shock in air\n",
-    "qr = [1000.0, 350.0, 2*101325.0] # Initial condition in still water\n",
-    "gamma = [7.15, 7.15]\n",
-    "pinf = [300000000.0, 300000000.0]\n",
-    "ex_states, ex_speeds, reval, wave_types, varsout = euler_tammann.exact_riemann_solution(ql ,qr, gamma, pinf, \n",
-    "                                                              varin = 'primitive', varout = 'primitive')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "plot_function = riemann_tools.make_plot_function(ex_states, ex_speeds, reval, wave_types, layout='vertical', \n",
-    "                                                 variable_names=euler_tammann.primitive_variables)\n",
-    "interact(plot_function, t=widgets.FloatSlider(value=0.0,min=0,max=1.0));"
+    "q_l = [1000.0, -350.0, 2*101325.0] # Initial condition for shock in air\n",
+    "q_r = [1000.0, 350.0, 2*101325.0] # Initial condition in still water\n",
+    "gamma = [gamma_water, gamma_water]\n",
+    "pinf = [pinf_water, pinf_water]\n",
+    "\n",
+    "plot_riemann_solution(q_l, q_r, gamma, pinf);"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### *Test: Interactive pplane for ideal gas Euler eqs. "
    ]
@@ -540,11 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initial states [density, velocity, pressure]\n",


### PR DESCRIPTION
Put repeated code into a function.
Use q_l instead of ql.
Introduce readable names for air and water parameters.